### PR TITLE
fix udev rules for 20.04

### DIFF
--- a/config/99-scarab.rules
+++ b/config/99-scarab.rules
@@ -2,7 +2,7 @@
 SUBSYSTEMS=="usb", KERNEL=="ttyACM[0-9]*", ATTRS{manufacturer}=="Hokuyo Data Flex for USB", SYMLINK+="hokuyo", MODE="0666"
 
 # Roboclaw
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2404", SYMLINK+="roboclaw", MODE="0666"
+SUBSYSTEMS=="usb", KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2404", SYMLINK+="roboclaw", MODE="0666"
 # Roboclaw permissions on /dev/bus/*/*, for libusb to work w/out root privilege
 SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2404", MODE="0666"
 
@@ -16,9 +16,6 @@ SUBSYSTEM=="tty", KERNEL=="ttyUSB*", ATTRS{serial}=="FTUTXLNS", SYMLINK+="bb04",
 SUBSYSTEM=="tty", KERNEL=="ttyUSB*", ATTRS{serial}=="A600QB9C", SYMLINK+="bb04", MODE="0666"
 SUBSYSTEM=="tty", KERNEL=="ttyUSB*", ATTRS{serial}=="A600QBPM", SYMLINK+="bb04", MODE="0666"
 SUBSYSTEM=="tty", KERNEL=="ttyUSB*", ATTRS{serial}=="A600QBCK", SYMLINK+="bb04", MODE="0666"
-
-# Servo
-#SUBSYSTEM=="tty", ATTRS{idVendor}=="067b", SYMLINK+="servo", MODE="0666"
 
 # Servo and FIDI Controller 
 SUBSYSTEM=="tty", KERNEL=="ttyUSB*", ATTRS{serial}=="AS05*", ATTRS{product}=="FT232R USB UART", SYMLINK+="servo", MODE="0666"


### PR DESCRIPTION
`/dev/roboclaw` was getting symlinked to a non tty device causing USBSerial to fail to connect; now it should link to the right device in `/dev/`.